### PR TITLE
Add limited support for LDAP password policy control

### DIFF
--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -84,6 +84,10 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/ChangePasswordAfterResetException.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/ChangePasswordAfterResetException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.storage.ldap;
+
+import javax.naming.AuthenticationException;
+
+public class ChangePasswordAfterResetException extends AuthenticationException {
+
+    public ChangePasswordAfterResetException() {
+        super();
+    }
+
+}

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -632,6 +633,15 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
             try {
                 ldapIdentityStore.validatePassword(ldapUser, password);
+                return true;
+            } catch (ChangePasswordAfterResetException e) {
+                if (user.getRequiredActionsStream()
+                        .noneMatch(action -> Objects.equals(action, UserModel.RequiredAction.UPDATE_PASSWORD.name()))) {
+                    logger.debugf("Adding requiredAction UPDATE_PASSWORD to user %s", user.getUsername());
+                    user.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+                } else {
+                    logger.tracef("Skip adding required action UPDATE_PASSWORD. It was already set on user '%s' in realm '%s'", user.getUsername(), realm.getName());
+                }
                 return true;
             } catch (AuthenticationException ae) {
                 AtomicReference<Boolean> processed = new AtomicReference<>(false);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -126,9 +126,6 @@ public final class LDAPContextManager implements AutoCloseable {
             throw new AuthenticationException("Could not negotiate TLS");
         }
 
-        // throws AuthenticationException when authentication fails
-        ldapContext.lookup("");
-
         return tls;
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -22,9 +22,12 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
+import org.keycloak.storage.ldap.ChangePasswordAfterResetException;
 import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
+import org.keycloak.storage.ldap.idm.store.ldap.control.PasswordPolicyResponseControl;
+import org.keycloak.storage.ldap.idm.store.ldap.control.PasswordPolicyResponseControlFactory;
 import org.keycloak.storage.ldap.idm.store.ldap.extended.PasswordModifyRequest;
 import org.keycloak.storage.ldap.mappers.LDAPOperationDecorator;
 import org.keycloak.truststore.TruststoreProvider;
@@ -41,6 +44,7 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.BasicControl;
 import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
@@ -502,14 +506,18 @@ public class LDAPOperationManager {
             // Never use connection pool to prevent password caching
             env.put("com.sun.jndi.ldap.connect.pool", "false");
 
-            if(!this.config.isStartTls()) {
+            // Send a passwordPolicyRequest control as non-critical.
+            env.put(LdapContext.CONTROL_FACTORIES, PasswordPolicyResponseControlFactory.class.getName());
+            Control[] connCtls = { new BasicControl(PasswordPolicyResponseControl.OID, false, null) };
+
+            if (!this.config.isStartTls()) {
                 env.put(Context.SECURITY_AUTHENTICATION, "simple");
                 env.put(Context.SECURITY_PRINCIPAL, dn);
                 env.put(Context.SECURITY_CREDENTIALS, password);
-            }
+                authCtx = new InitialLdapContext(env, connCtls);
+            } else {
+                authCtx = new InitialLdapContext(env, null);
 
-            authCtx = new InitialLdapContext(env, null);
-            if (config.isStartTls()) {
                 SSLSocketFactory sslSocketFactory = null;
                 String useTruststoreSpi = config.getUseTruststoreSpi();
                 if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
@@ -523,7 +531,25 @@ public class LDAPOperationManager {
                 if (tlsResponse == null) {
                     throw new AuthenticationException("Null TLS Response returned from the authentication");
                 }
+
+                // Explicitly initiate bind with given request controls.
+                // Throws AuthenticationException when authentication fails.
+                authCtx.reconnect(connCtls);
             }
+
+            // Check for password policy response control in the response. If present and forced password change is required, throw an exception.
+            Control[] responseControls = authCtx.getResponseControls();
+            if (responseControls != null) {
+                for (Control control : responseControls) {
+                    if (control instanceof PasswordPolicyResponseControl) {
+                        PasswordPolicyResponseControl response = (PasswordPolicyResponseControl) control;
+                        if (response.changeAfterReset()) {
+                            throw new ChangePasswordAfterResetException();
+                        }
+                    }
+                }
+            }
+
         } catch (AuthenticationException ae) {
             if (logger.isDebugEnabled()) {
                 logger.debugf(ae, "Authentication failed for DN [%s]", dn);
@@ -534,7 +560,7 @@ public class LDAPOperationManager {
             if (logger.isDebugEnabled()) {
                 logger.debugf(re, "LDAP Connection TimeOut for DN [%s]", dn);
             }
-            
+
             throw re;
 
         } catch (Exception e) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyResponseControl.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyResponseControl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.storage.ldap.idm.store.ldap.control;
+
+import java.math.BigInteger;
+
+import javax.naming.ldap.Control;
+
+import org.jboss.logging.Logger;
+import org.wildfly.security.asn1.ASN1;
+import org.wildfly.security.asn1.ASN1Exception;
+import org.wildfly.security.asn1.DERDecoder;
+
+public class PasswordPolicyResponseControl implements Control {
+
+    public static final String OID = "1.3.6.1.4.1.42.2.27.8.5.1";
+
+    private static final Logger logger = Logger.getLogger(PasswordPolicyResponseControl.class);
+
+    private static final int ERROR_CHANGE_AFTER_RESET = 2;
+
+    private boolean changeAfterReset;
+
+    /*
+     * https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy-11#section-6.2
+     *
+     * PasswordPolicyResponseValue ::= SEQUENCE {
+     *    warning [0] CHOICE {
+     *       timeBeforeExpiration [0] INTEGER (0 .. maxInt),
+     *       graceAuthNsRemaining [1] INTEGER (0 .. maxInt) } OPTIONAL,
+     *    error   [1] ENUMERATED {
+     *       passwordExpired             (0),
+     *       accountLocked               (1),
+     *       changeAfterReset            (2),
+     *       passwordModNotAllowed       (3),
+     *       mustSupplyOldPassword       (4),
+     *       insufficientPasswordQuality (5),
+     *       passwordTooShort            (6),
+     *       passwordTooYoung            (7),
+     *       passwordInHistory           (8),
+     *       passwordTooLong             (9) } OPTIONAL }
+     */
+
+    PasswordPolicyResponseControl(byte[] encodedValue) {
+        DERDecoder der = new DERDecoder(encodedValue);
+
+        try {
+            der.startSequence(); // PasswordPolicyResponseValue ::= SEQUENCE
+            if (der.isNextType(ASN1.CONTEXT_SPECIFIC_MASK, 0, false)) { // warning [0] CHOICE
+                der.skipElement();
+            }
+            if (der.isNextType(ASN1.CONTEXT_SPECIFIC_MASK, 1, false)) { // error   [1] ENUMERATED
+                der.decodeImplicit(1);
+                this.changeAfterReset = new BigInteger(der.drainElementValue()).intValue() == ERROR_CHANGE_AFTER_RESET;
+            }
+            der.endSequence();
+        } catch (ASN1Exception ignored) {
+            logger.errorf("Failed to parse PasswordPolicyResponseControl value: %s", ignored.getMessage());
+        }
+    }
+
+    public boolean changeAfterReset() {
+        return changeAfterReset;
+    }
+
+    @Override
+    public String getID() {
+        return OID;
+    }
+
+    @Override
+    public boolean isCritical() {
+        return Control.NONCRITICAL;
+    }
+
+    @Override
+    public byte[] getEncodedValue() {
+        return new byte[0];
+    }
+
+}

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyResponseControlFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyResponseControlFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.keycloak.storage.ldap.idm.store.ldap.control;
+
+import javax.naming.NamingException;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.ControlFactory;
+
+public class PasswordPolicyResponseControlFactory extends ControlFactory {
+
+    @Override
+    public Control getControlInstance(Control ctl) throws NamingException {
+        if (ctl.getID().equals(PasswordPolicyResponseControl.OID)) {
+            return new PasswordPolicyResponseControl(ctl.getEncodedValue());
+        }
+        return null;
+    }
+
+}

--- a/model/map-ldap/pom.xml
+++ b/model/map-ldap/pom.xml
@@ -37,6 +37,10 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
     <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/ChangePasswordAfterResetException.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/ChangePasswordAfterResetException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.ldap.store;
+
+import javax.naming.AuthenticationException;
+
+public class ChangePasswordAfterResetException extends AuthenticationException {
+
+    public ChangePasswordAfterResetException() {
+        super();
+    }
+
+}

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapContextManager.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapContextManager.java
@@ -142,9 +142,6 @@ public final class LdapMapContextManager implements AutoCloseable {
             throw new AuthenticationException("Could not negotiate TLS");
         }
 
-        // throws AuthenticationException when authentication fails
-        ldapContext.lookup("");
-
         return tls;
     }
 

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapOperationManager.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapOperationManager.java
@@ -24,6 +24,8 @@ import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.map.storage.ldap.config.LdapMapConfig;
 import org.keycloak.models.map.storage.ldap.model.LdapMapDn;
+import org.keycloak.models.map.storage.ldap.store.control.PasswordPolicyResponseControl;
+import org.keycloak.models.map.storage.ldap.store.control.PasswordPolicyResponseControlFactory;
 import org.keycloak.truststore.TruststoreProvider;
 
 import javax.naming.AuthenticationException;
@@ -38,6 +40,8 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.BasicControl;
+import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
@@ -396,14 +400,18 @@ public class LdapMapOperationManager implements AutoCloseable {
             // Never use connection pool to prevent password caching
             env.put("com.sun.jndi.ldap.connect.pool", "false");
 
+            // Send a passwordPolicyRequest control as non-critical.
+            env.put(LdapContext.CONTROL_FACTORIES, PasswordPolicyResponseControlFactory.class.getName());
+            Control[] connCtls = { new BasicControl(PasswordPolicyResponseControl.OID, false, null) };
+
             if(!this.config.isStartTls()) {
                 env.put(Context.SECURITY_AUTHENTICATION, "simple");
                 env.put(Context.SECURITY_PRINCIPAL, dn);
                 env.put(Context.SECURITY_CREDENTIALS, password);
-            }
+                authCtx = new InitialLdapContext(env, connCtls);
+            } else {
+                authCtx = new InitialLdapContext(env, null);
 
-            authCtx = new InitialLdapContext(env, null);
-            if (config.isStartTls()) {
                 SSLSocketFactory sslSocketFactory = null;
                 String useTruststoreSpi = config.getUseTruststoreSpi();
                 if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
@@ -417,7 +425,25 @@ public class LdapMapOperationManager implements AutoCloseable {
                 if (tlsResponse == null) {
                     throw new AuthenticationException("Null TLS Response returned from the authentication");
                 }
+
+                // Explicitly initiate bind with given request controls.
+                // Throws AuthenticationException when authentication fails.
+                authCtx.reconnect(connCtls);
             }
+
+            // Check for password policy response control in the response. If present and forced password change is required, throw an exception.
+            Control[] responseControls = authCtx.getResponseControls();
+            if (responseControls != null) {
+                for (Control control : responseControls) {
+                    if (control instanceof PasswordPolicyResponseControl) {
+                        PasswordPolicyResponseControl response = (PasswordPolicyResponseControl) control;
+                        if (response.changeAfterReset()) {
+                            throw new ChangePasswordAfterResetException();
+                        }
+                    }
+                }
+            }
+
         } catch (AuthenticationException ae) {
             if (logger.isDebugEnabled()) {
                 logger.debugf(ae, "Authentication failed for DN [%s]", dn);
@@ -428,7 +454,7 @@ public class LdapMapOperationManager implements AutoCloseable {
             if (logger.isDebugEnabled()) {
                 logger.debugf(re, "LDAP Connection TimeOut for DN [%s]", dn);
             }
-            
+
             throw re;
 
         } catch (Exception e) {

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/control/PasswordPolicyResponseControl.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/control/PasswordPolicyResponseControl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.ldap.store.control;
+
+import java.math.BigInteger;
+
+import javax.naming.ldap.Control;
+
+import org.jboss.logging.Logger;
+import org.wildfly.security.asn1.ASN1;
+import org.wildfly.security.asn1.ASN1Exception;
+import org.wildfly.security.asn1.DERDecoder;
+
+public class PasswordPolicyResponseControl implements Control {
+
+    public static final String OID = "1.3.6.1.4.1.42.2.27.8.5.1";
+
+    private static final Logger logger = Logger.getLogger(PasswordPolicyResponseControl.class);
+
+    private static final int ERROR_CHANGE_AFTER_RESET = 2;
+
+    private boolean changeAfterReset;
+
+    /*
+     * https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy-11#section-6.2
+     *
+     * PasswordPolicyResponseValue ::= SEQUENCE {
+     *    warning [0] CHOICE {
+     *       timeBeforeExpiration [0] INTEGER (0 .. maxInt),
+     *       graceAuthNsRemaining [1] INTEGER (0 .. maxInt) } OPTIONAL,
+     *    error   [1] ENUMERATED {
+     *       passwordExpired             (0),
+     *       accountLocked               (1),
+     *       changeAfterReset            (2),
+     *       passwordModNotAllowed       (3),
+     *       mustSupplyOldPassword       (4),
+     *       insufficientPasswordQuality (5),
+     *       passwordTooShort            (6),
+     *       passwordTooYoung            (7),
+     *       passwordInHistory           (8),
+     *       passwordTooLong             (9) } OPTIONAL }
+     */
+
+    PasswordPolicyResponseControl(byte[] encodedValue) {
+        DERDecoder der = new DERDecoder(encodedValue);
+
+        try {
+            der.startSequence(); // PasswordPolicyResponseValue ::= SEQUENCE
+            if (der.isNextType(ASN1.CONTEXT_SPECIFIC_MASK, 0, false)) { // warning [0] CHOICE
+                der.skipElement();
+            }
+            if (der.isNextType(ASN1.CONTEXT_SPECIFIC_MASK, 1, false)) { // error   [1] ENUMERATED
+                der.decodeImplicit(1);
+                this.changeAfterReset = new BigInteger(der.drainElementValue()).intValue() == ERROR_CHANGE_AFTER_RESET;
+            }
+            der.endSequence();
+        } catch (ASN1Exception ignored) {
+            logger.errorf("Failed to parse PasswordPolicyResponseControl value: %s", ignored.getMessage());
+        }
+    }
+
+    public boolean changeAfterReset() {
+        return changeAfterReset;
+    }
+
+    @Override
+    public String getID() {
+        return OID;
+    }
+
+    @Override
+    public boolean isCritical() {
+        return Control.NONCRITICAL;
+    }
+
+    @Override
+    public byte[] getEncodedValue() {
+        return new byte[0];
+    }
+
+}

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/control/PasswordPolicyResponseControlFactory.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/control/PasswordPolicyResponseControlFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.ldap.store.control;
+
+import javax.naming.NamingException;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.ControlFactory;
+
+public class PasswordPolicyResponseControlFactory extends ControlFactory {
+
+    @Override
+    public Control getControlInstance(Control ctl) throws NamingException {
+        if (ctl.getID().equals(PasswordPolicyResponseControl.OID)) {
+            return new PasswordPolicyResponseControl(ctl.getEncodedValue());
+        }
+        return null;
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -160,6 +160,17 @@ public class LDAPRule extends ExternalResource {
                     break;
             }
         }
+
+        Annotation passwordPolicyAnnotations = description.getAnnotation(LDAPPasswordPolicy.class);
+        if (passwordPolicyAnnotations != null) {
+            LDAPPasswordPolicy passwordPolicy = (LDAPPasswordPolicy) passwordPolicyAnnotations;
+
+            log.debugf("Enabling LDAP password policy: mustChange=%s.", passwordPolicy.mustChange());
+
+            defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_PPOLICY_ENABLED, "true");
+            defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_PPOLICY_MUST_CHANGE, String.valueOf(passwordPolicy.mustChange()));
+        }
+
         return super.apply(base, description);
     }
 
@@ -303,5 +314,11 @@ public class LDAPRule extends ExternalResource {
             SSL,
             STARTTLS
         }
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface LDAPPasswordPolicy {
+        public boolean mustChange() default false;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordPolicyTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.testsuite.federation.ldap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.models.RealmModel;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.testsuite.util.LDAPRule;
+import org.keycloak.testsuite.util.LDAPTestConfiguration;
+import org.keycloak.testsuite.util.LDAPTestUtils;
+import org.keycloak.testsuite.util.LDAPRule.LDAPPasswordPolicy;
+
+public class LDAPPasswordPolicyTest extends AbstractLDAPTest {
+
+    @Rule
+    // Start an embedded LDAP server with configuration derived from test annotations before each test.
+    public LDAPRule ldapRule = new LDAPRule()
+        .assumeTrue((LDAPTestConfiguration ldapConfig) -> {
+            return ldapConfig.isStartEmbeddedLdapServer();
+        });
+
+    @Override
+    protected LDAPRule getLDAPRule() {
+        return ldapRule;
+    }
+
+    @Override
+    protected void afterImportTestRealm() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            LDAPObject user = LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "mustchange", "John", "Doe",
+                    "john_old@email.org", null, "1234");
+            LDAPTestUtils.updateLDAPPassword(ctx.getLdapProvider(), user, "Password1");
+        });
+    }
+
+    @Test
+    @LDAPPasswordPolicy(mustChange=true)
+    public void testForcedPasswordChangeAfterReset() throws Exception {
+        // Login with user that has to change password.
+        loginPage.open();
+        loginPage.login("mustchange", "Password1");
+
+        // Forced password change sends user to update password page.
+        passwordUpdatePage.assertCurrent();
+
+        // Repeated login without changing password should still send user to update password page.
+        loginPage.open();
+        loginPage.login("mustchange", "Password1");
+        passwordUpdatePage.assertCurrent();
+    }
+
+}

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
@@ -23,13 +23,18 @@ import org.apache.commons.lang.text.StrSubstitutor;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.exception.LdapEntryAlreadyExistsException;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.InterceptorEnum;
+import org.apache.directory.server.core.api.authn.ppolicy.PasswordPolicyConfiguration;
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.directory.server.core.api.partition.Partition;
-import org.apache.directory.server.core.factory.AvlPartitionFactory;
+import org.apache.directory.server.core.authn.AuthenticationInterceptor;
+import org.apache.directory.server.core.authn.ppolicy.PpolicyConfigContainer;
 import org.apache.directory.server.core.factory.DefaultDirectoryServiceFactory;
 import org.apache.directory.server.core.factory.JdbmPartitionFactory;
 import org.apache.directory.server.core.normalization.NormalizationInterceptor;
@@ -70,6 +75,8 @@ public class LDAPEmbeddedServer {
     public static final String PROPERTY_ENABLE_SSL = "enableSSL";
     public static final String PROPERTY_ENABLE_STARTTLS = "enableStartTLS";
     public static final String PROPERTY_SET_CONFIDENTIALITY_REQUIRED = "setConfidentialityRequired";
+    public static final String PROPERTY_PPOLICY_ENABLED = "ppolicy.enabled";
+    public static final String PROPERTY_PPOLICY_MUST_CHANGE = "ppolicy.mustChange";
 
     private static final String DEFAULT_BASE_DN = "dc=keycloak,dc=org";
     private static final String DEFAULT_BIND_HOST = "localhost";
@@ -99,6 +106,8 @@ public class LDAPEmbeddedServer {
     protected boolean setConfidentialityRequired = false;
     protected String keystoreFile;
     protected String certPassword;
+    protected boolean ppolicyEnabled = false;
+    protected boolean ppolicyMustChange = false;
 
     protected DirectoryService directoryService;
     protected LdapServer ldapServer;
@@ -156,6 +165,8 @@ public class LDAPEmbeddedServer {
         this.setConfidentialityRequired = Boolean.valueOf(readProperty(PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "false"));
         this.keystoreFile = readProperty(PROPERTY_KEYSTORE_FILE, null);
         this.certPassword = readProperty(PROPERTY_CERTIFICATE_PASSWORD, null);
+        this.ppolicyEnabled = Boolean.valueOf(readProperty(PROPERTY_PPOLICY_MUST_CHANGE, "false"));
+        this.ppolicyMustChange = Boolean.valueOf(readProperty(PROPERTY_PPOLICY_MUST_CHANGE, "false"));
     }
 
     protected String readProperty(String propertyName, String defaultValue) {
@@ -184,6 +195,11 @@ public class LDAPEmbeddedServer {
 
         log.info("Creating LDAP server..");
         this.ldapServer = createLdapServer();
+
+        if (this.ppolicyEnabled) {
+            log.info("Enabling Password Policy");
+            createDefaultPasswordPolicy();
+        }
     }
 
 
@@ -414,6 +430,21 @@ public class LDAPEmbeddedServer {
         } else {
             log.info("Working LDAP directory not deleted. Delete it manually if you want to start with fresh LDAP data. Directory location: " + instanceDir.getAbsolutePath());
         }
+    }
+
+    protected void createDefaultPasswordPolicy() throws LdapInvalidDnException {
+        AuthenticationInterceptor authenticationInterceptor = (AuthenticationInterceptor) this.directoryService
+                .getInterceptor(InterceptorEnum.AUTHENTICATION_INTERCEPTOR.getName());
+        PasswordPolicyConfiguration policyConfig = new PasswordPolicyConfiguration();
+        policyConfig.setPwdMustChange(true);
+
+        PpolicyConfigContainer policyContainer = new PpolicyConfigContainer();
+        Dn defaultPolicyDn = new Dn( ldapServer.getDirectoryService().getSchemaManager(), "cn=defaultPasswordPolicy" );
+
+        policyContainer.addPolicy( defaultPolicyDn, policyConfig );
+        policyContainer.setDefaultPolicyDn( defaultPolicyDn );
+
+        authenticationInterceptor.setPwdPolicies( policyContainer );
     }
 
 }


### PR DESCRIPTION
Send password policy control during LDAP bind operation and receive response according to chapter 9.1 of [1].  When server responds with error "changeAfterReset" prompt user to update their password by adding UPDATE_PASSWORD required action.

[1] https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy-11

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
