### PR TITLE
Added keystore SPI support.

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -4,7 +4,6 @@ import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.storage.ldap.LDAPConfig;
-import org.keycloak.truststore.TruststoreProvider;
 import org.keycloak.vault.VaultCharSecret;
 
 import javax.naming.AuthenticationException;
@@ -59,6 +58,12 @@ public final class LDAPContextManager implements AutoCloseable {
     public LDAPContextManager(KeycloakSession session, LDAPConfig connectionProperties) {
         this.session = session;
         this.ldapConfig = connectionProperties;
+
+        String useTruststoreSpi = connectionProperties.getUseTruststoreSpi();
+        if (useTruststoreSpi != null && !useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_NEVER)) {
+            // Initialize LDAP socket factory that utilizes TrustStore SPI and KeyStore SPI.
+            LDAPSSLSocketFactory.initialize(session);
+        }
     }
 
     public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties) {
@@ -82,8 +87,7 @@ public final class LDAPContextManager implements AutoCloseable {
             SSLSocketFactory sslSocketFactory = null;
             String useTruststoreSpi = ldapConfig.getUseTruststoreSpi();
             if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
-                TruststoreProvider provider = session.getProvider(TruststoreProvider.class);
-                sslSocketFactory = provider.getSSLSocketFactory();
+                sslSocketFactory = LDAPSSLSocketFactory.getDefault();
             }
 
             tlsResponse = startTLS(ldapContext, ldapConfig.getAuthType(), ldapConfig.getBindDN(),

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -27,7 +27,6 @@ import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
 import org.keycloak.storage.ldap.idm.store.ldap.extended.PasswordModifyRequest;
 import org.keycloak.storage.ldap.mappers.LDAPOperationDecorator;
-import org.keycloak.truststore.TruststoreProvider;
 
 import javax.naming.AuthenticationException;
 import javax.naming.Binding;
@@ -512,8 +511,10 @@ public class LDAPOperationManager {
                 SSLSocketFactory sslSocketFactory = null;
                 String useTruststoreSpi = config.getUseTruststoreSpi();
                 if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_ALWAYS)) {
-                    TruststoreProvider provider = session.getProvider(TruststoreProvider.class);
-                    sslSocketFactory = provider.getSSLSocketFactory();
+                    // In this code path LDAPContextManager is not used, so we'd need to make sure that
+                    // the SSL socket factory has been initialized before using.
+                    LDAPSSLSocketFactory.initialize(session);
+                    sslSocketFactory = LDAPSSLSocketFactory.getDefault();
                 }
 
                 tlsResponse = LDAPContextManager.startTLS(authCtx, "simple", dn, password.toCharArray(), sslSocketFactory);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPSSLSocketFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPSSLSocketFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.storage.ldap.idm.store.ldap;
+
+import org.jboss.logging.Logger;
+import org.keycloak.keystore.KeyStoreProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.truststore.TruststoreProvider;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyStoreBuilderParameters;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+
+public class LDAPSSLSocketFactory extends SSLSocketFactory implements Comparator<String> {
+
+    private static final String NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY = "Not implemented by LDAPSSLSocketFactory";
+
+    private static final Logger log = Logger.getLogger(LDAPSSLSocketFactory.class);
+
+    private static SSLSocketFactory instance = null;
+
+    private LDAPSSLSocketFactory() {
+    }
+
+    public static synchronized void initialize(KeycloakSession session) {
+        if (instance == null) {
+            try {
+                // Initialize TrustManager with TrustStore provided by TrustStore SPI.
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                TruststoreProvider tsp = session.getProvider(TruststoreProvider.class);
+                if (tsp == null) {
+                    new RuntimeException("Truststore SPI used but Truststore was not configured");
+                }
+                tmf.init(tsp.getTruststore());
+                TrustManager[] tms = tmf.getTrustManagers();
+
+                // Initialize KeyManager with KeyStore provided by KeyStore SPI.
+                KeyManager[] kms = null;
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509");
+                KeyStore.Builder ksb = session.getProvider(KeyStoreProvider.class)
+                        .loadKeyStoreBuilder(KeyStoreProvider.LDAP_CLIENT_KEYSTORE);
+                if (ksb != null) {
+                    kmf.init(new KeyStoreBuilderParameters(ksb));
+                    kms = kmf.getKeyManagers();
+                }
+
+                log.infov("Initializing LDAPSSLSocketFactory: trustStore={0}, keyStore={1}",
+                        tms != null ? "yes" : "no",
+                        kms != null ? "yes" : "no");
+
+                SSLContext context = SSLContext.getInstance("TLS");
+                context.init(kms, tms, null);
+
+                instance = context.getSocketFactory();
+            } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException | InvalidAlgorithmParameterException e) {
+                log.error("Failed to initialize SSLContext for LDAP: " + e.toString());
+                throw new RuntimeException("Failed to initialize SSLContext: " + e.toString());
+            }
+        }
+    }
+
+    public static SSLSocketFactory getDefault() {
+        return instance;
+    }
+
+    /**
+     * Enables LDAP connection pooling for sockets from custom socket factory.
+     * See https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/jndi-ldap.html#pooling
+     *
+     * Note that Comparator<String> needs to be implemented since JDK uses the class name as string for the comparison.
+     *
+     * For more information, see:
+     * https://stackoverflow.com/questions/23898970/pooling-ldap-connections-with-custom-socket-factory
+     * https://bugs.openjdk.org/browse/JDK-6587244?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aworklog-tabpanel
+     */
+    @Override
+    public int compare(String o1, String o2) {
+        return o1.compareTo(o2);
+    }
+
+    // Following methods are not used by the JNDI LDAP implementation and therefore do not need to be implemented.
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+            throws IOException {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+            throws IOException {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        throw new UnsupportedOperationException(NOT_IMPLEMENTED_BY_LDAP_SOCKET_FACTORY);
+    }
+
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/VertxCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/VertxCustomizer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.quarkus.runtime;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
+import org.keycloak.keystore.KeyStoreProvider;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyStoreBuilderParameters;
+import javax.net.ssl.X509KeyManager;
+
+import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.KeyCertOptions;
+
+@ApplicationScoped
+public class VertxCustomizer implements HttpServerOptionsCustomizer {
+
+    private static final Logger log = Logger.getLogger(VertxCustomizer.class);
+
+    @Override
+    public void customizeHttpsServer(HttpServerOptions options) {
+        try {
+            QuarkusKeycloakSessionFactory instance = QuarkusKeycloakSessionFactory.getInstance();
+            KeycloakSession session = instance.create();
+
+            KeyStore.Builder ksb = session.getProvider(KeyStoreProvider.class)
+                    .loadKeyStoreBuilder(KeyStoreProvider.HTTPS_SERVER_KEYSTORE);
+            if (ksb != null) {
+                log.info("Setting KeyStore to Vert.x");
+                KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509");
+                kmf.init(new KeyStoreBuilderParameters(ksb));
+                KeyCertOptions kco = KeyCertOptions.wrap((X509KeyManager) kmf.getKeyManagers()[0]);
+                options.setKeyCertOptions(kco);
+            }
+        } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+            log.error("Failed to set KeyManager: " + e.toString());
+            throw new RuntimeException("Failed to set KeyManager: " + e.toString());
+        }
+
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -64,25 +64,25 @@ final class HttpPropertyMappers {
                         .paramLabel("protocols")
                         .build(),
                 fromOption(HttpOptions.HTTPS_CERTIFICATE_FILE)
-                        .to("quarkus.http.ssl.certificate.file")
+                        .to("kc.spi-keystore-default-https-certificate-file")
                         .paramLabel("file")
                         .build(),
                 fromOption(HttpOptions.HTTPS_CERTIFICATE_KEY_FILE)
-                        .to("quarkus.http.ssl.certificate.key-file")
+                        .to("kc.spi-keystore-default-https-certificate-key-file")
                         .paramLabel("file")
                         .build(),
                 fromOption(HttpOptions.HTTPS_KEY_STORE_FILE
-                            .withRuntimeSpecificDefault(getDefaultKeystorePathValue()))
-                        .to("quarkus.http.ssl.certificate.key-store-file")
+                        .withRuntimeSpecificDefault(getDefaultKeystorePathValue()))
+                        .to("kc.spi-keystore-default-https-keystore-file")
                         .paramLabel("file")
                         .build(),
                 fromOption(HttpOptions.HTTPS_KEY_STORE_PASSWORD)
-                        .to("quarkus.http.ssl.certificate.key-store-password")
+                        .to("kc.spi-keystore-default-https-keystore-password")
                         .paramLabel("password")
                         .isMasked(true)
                         .build(),
                 fromOption(HttpOptions.HTTPS_KEY_STORE_TYPE)
-                        .to("quarkus.http.ssl.certificate.key-store-file-type")
+                        .to("kc.spi-keystore-default-https-keystore-type")
                         .mapFrom(SecurityOptions.FIPS_MODE.getKey())
                         .transformer(HttpPropertyMappers::resolveKeyStoreType)
                         .paramLabel("type")
@@ -118,7 +118,7 @@ final class HttpPropertyMappers {
             ConfigValue proceed = context.proceed("kc.https-certificate-file");
 
             if (proceed == null || proceed.getValue() == null) {
-                proceed = getMapper("quarkus.http.ssl.certificate.key-store-file").getConfigValue(context);
+                proceed = getMapper("kc.spi-keystore-default-https-keystore-file").getConfigValue(context);
             }
 
             if (proceed == null || proceed.getValue() == null) {
@@ -157,4 +157,3 @@ final class HttpPropertyMappers {
         return value;
     }
 }
-

--- a/server-spi-private/src/main/java/org/keycloak/keystore/KeyStoreProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/keystore/KeyStoreProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.security.KeyStore;
+
+import org.keycloak.provider.Provider;
+
+/**
+ * KeyStore provider provides credentials for clients and servers.
+ */
+public interface KeyStoreProvider extends Provider {
+
+    public static final String LDAP_CLIENT_KEYSTORE = "ldap-client-keystore";
+    public static final String HTTPS_SERVER_KEYSTORE = "https-server-keystore";
+
+    /**
+     * Loads KeyStore of given identifier.
+     *
+     * @param keyStoreIdentifier Identifier of the wanted KeyStore, such as LDAP_CLIENT_KEYSTORE.
+     * @return KeyStore.
+     */
+    KeyStore loadKeyStore(String keyStoreIdentifier);
+
+    /**
+     * Loads KeyStore of given identifier and returns a KeyStore.Builder.
+     * Builder encapsulates both KeyStore and KeyEntry password(s).
+     *
+     * @param keyStoreIdentifier Identifier of the wanted KeyStore, such as LDAP_CLIENT_KEYSTORE.
+     * @return Builder for KeyStore.
+     */
+
+    KeyStore.Builder loadKeyStoreBuilder(String keyStoreIdentifier);
+
+}

--- a/server-spi-private/src/main/java/org/keycloak/keystore/KeyStoreProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/keystore/KeyStoreProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface KeyStoreProviderFactory extends ProviderFactory<KeyStoreProvider> {
+}

--- a/server-spi-private/src/main/java/org/keycloak/keystore/KeyStoreSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/keystore/KeyStoreSpi.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class KeyStoreSpi implements Spi {
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "keystore";
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return KeyStoreProvider.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return KeyStoreProviderFactory.class;
+    }
+
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -55,6 +55,7 @@ public class LDAPConstants {
     public static final String AUTH_TYPE = "authType";
     public static final String AUTH_TYPE_NONE = "none";
     public static final String AUTH_TYPE_SIMPLE = "simple";
+    public static final String AUTH_TYPE_EXTERNAL = "EXTERNAL";
 
     public static final String USE_TRUSTSTORE_SPI = "useTruststoreSpi";
     public static final String USE_TRUSTSTORE_ALWAYS = "always";
@@ -171,7 +172,7 @@ public class LDAPConstants {
         }
 
         if (shouldSetTruststore) {
-            env.put("java.naming.ldap.factory.socket", "org.keycloak.truststore.SSLSocketFactory");
+            env.put("java.naming.ldap.factory.socket", "org.keycloak.storage.ldap.idm.store.ldap.LDAPSSLSocketFactory");
         }
     }
 

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -52,6 +52,7 @@ org.keycloak.email.EmailSenderSpi
 org.keycloak.email.EmailTemplateSpi
 org.keycloak.executors.ExecutorsSpi
 org.keycloak.theme.ThemeSpi
+org.keycloak.keystore.KeyStoreSpi
 org.keycloak.truststore.TruststoreSpi
 org.keycloak.connections.httpclient.HttpClientSpi
 org.keycloak.authentication.AuthenticatorSpi

--- a/services/src/main/java/org/keycloak/keystore/DefaultKeyStoreProvider.java
+++ b/services/src/main/java/org/keycloak/keystore/DefaultKeyStoreProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStore.Builder;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
+
+import org.jboss.logging.Logger;
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class DefaultKeyStoreProvider implements KeyStoreProvider, KeyStoreProviderFactory {
+
+    private static final Logger log = Logger.getLogger(DefaultKeyStoreProvider.class);
+
+    private KeyStore.Builder ldapKeyStoreBuilder;
+    private KeyStore.Builder httpsKeyStoreBuilder;
+
+    @Override
+    public void close() {
+        // Nothing to do here.
+    }
+
+    /**
+     * Returns named keystore.
+     *
+     * @param keyStoreIdentifier The identifier of requested keystore.
+     * @return Reference to a keystore.
+     * @throws KeyStoreException
+     */
+    @Override
+    public KeyStore loadKeyStore(String keyStoreIdentifier) {
+        try {
+            return loadKeyStoreBuilder(keyStoreIdentifier).getKeyStore();
+        } catch (KeyStoreException e) {
+            log.errorv("Cannot load KeyStore {0}", keyStoreIdentifier);
+            throw new RuntimeException("Cannot load KeyStore " + keyStoreIdentifier + ":" + e.getMessage());
+        }
+    }
+
+    @Override
+    public Builder loadKeyStoreBuilder(String keyStoreIdentifier) {
+        log.infov("loadKeyStoreBuilder was called with keystore identifier {0}", keyStoreIdentifier);
+        if (keyStoreIdentifier.equals(LDAP_CLIENT_KEYSTORE)) {
+            return ldapKeyStoreBuilder;
+        }
+        if (keyStoreIdentifier.equals(HTTPS_SERVER_KEYSTORE)) {
+            return httpsKeyStoreBuilder;
+        }
+
+        log.errorv("loadKeyStoreBuilder was called with invalid keystore identifier {0}", keyStoreIdentifier);
+        throw new IllegalArgumentException("invalid keystore requested, keyStoreIdentifier:" + keyStoreIdentifier);
+    }
+
+    @Override
+    public KeyStoreProvider create(KeycloakSession session) {
+        return this;
+    }
+
+    @Override
+    public void init(Scope config) {
+        // Allow changing the default duration that defines how frequently at most the backing file(s) will be checked
+        // for modification. The value is parsed as ISO8601 time duration (e.g. "1s", "2m30s", "1h").
+        String cacheTtl = config.get("keyStoreCacheTtl");
+        if (cacheTtl != null) {
+            log.infov("Setting reloading keyStore cache TTL to {0}", cacheTtl);
+            ReloadingKeyStore.setDefaultKeyStoreCacheTtl(Duration.parse("PT" + cacheTtl));
+        }
+
+        ldapKeyStoreBuilder = getKeyStore(config, "ldap");
+        httpsKeyStoreBuilder = getKeyStore(config, "https");
+    }
+
+    private KeyStore.Builder getKeyStore(Scope config, String prefix) {
+        KeyStore.Builder keyStoreBuilder = null;
+
+        // Check if credentials are given as PEM files.
+        log.debugv("Checking for PEM files for {0}", prefix);
+        String certificateFile = config.get(prefix + "CertificateFile");
+        String certificateKeyFile = config.get(prefix + "CertificateKeyFile");
+        if (certificateFile != null && certificateKeyFile != null) {
+            log.infov("Loading credentials: {0}, {1}", certificateFile, certificateKeyFile);
+            try {
+                keyStoreBuilder = ReloadingKeyStore.Builder.fromPem(Paths.get(certificateFile),
+                        Paths.get(certificateKeyFile));
+            } catch (NoSuchAlgorithmException | CertificateException | IllegalArgumentException | KeyStoreException
+                    | InvalidKeySpecException | IOException e) {
+                throw new RuntimeException("Failed to initialize " + prefix + " keystore: " + e.toString());
+            }
+        }
+
+        // Check if credentials are given as KeyStore file.
+        String keyStoreFile = config.get(prefix + "KeystoreFile");
+        String keyStorePassword = config.get(prefix + "KeystorePassword");
+        String keyStoreType = config.get(prefix + "KeystoreType", "JKS");
+
+        // Check if both PEM files and KeyStore is configured.
+        if (keyStoreBuilder != null && keyStoreFile != null) {
+            log.errorv("Both PEM files and KeyStore was configured for {0}. Choose only one.", prefix);
+            throw new IllegalArgumentException("Both PEM files and KeyStore was configured for " + prefix + ". Choose only one.");
+        }
+
+        // Check if keyStore file is configured without password.
+        if (keyStoreFile != null && keyStorePassword == null) {
+            log.errorv("Password not given for {0} keystore {1}", prefix, keyStoreFile);
+            throw new IllegalArgumentException("Password not given for " + prefix + " keystore: " + keyStoreFile);
+        }
+
+        log.debugv("Checking for keystore file for {0}", prefix);
+        if (keyStoreFile != null) {
+            try {
+                log.infov("Loading credentials for {0}: {1}", prefix, keyStoreFile);
+                keyStoreBuilder = ReloadingKeyStore.Builder
+                        .fromKeyStoreFile(keyStoreType, Paths.get(keyStoreFile), keyStorePassword);
+            } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+                throw new RuntimeException("Failed to initialize " + prefix + " keystore: " + e.toString());
+            }
+        }
+
+        return keyStoreBuilder;
+    }
+
+    @Override
+    public String getId() {
+        return "default";
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // Nothing to do here.
+    }
+
+
+
+}

--- a/services/src/main/java/org/keycloak/keystore/DelegatingKeyStoreSpi.java
+++ b/services/src/main/java/org/keycloak/keystore/DelegatingKeyStoreSpi.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Implementation of {@code KeyStoreSpi} that delegates calls to an instance of {@code KeyStore}.
+ * The delegate keystore can be replaced on demand when the underlying certificate(s) and key(s) change.
+ */
+public abstract class DelegatingKeyStoreSpi extends KeyStoreSpi {
+
+    private static final Logger log = Logger.getLogger(DelegatingKeyStoreSpi.class);
+
+    // Use Clock instance instead of Instant.now(). This allows mocked clock to be injected from test cases(s).
+    static Clock now = Clock.systemUTC();
+
+    // Defines how often the delegate keystore should be checked for updates.
+    static Duration cacheTtl = Duration.of(1, ChronoUnit.SECONDS);
+
+    private AtomicReference<Delegate> delegate = new AtomicReference<>();
+
+    // Defines the next time when to check updates.
+    private Instant cacheExpiredTime = Instant.MIN;
+
+    /**
+     * Reloads the delegate KeyStore if the underlying files have changed on disk.
+     */
+    abstract void refresh() throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException,
+            InvalidKeySpecException;
+
+    /**
+     * Calls {@link #refresh()} to refresh the cached KeyStore and if more than
+     * {@link #cacheTtl} has passed since last
+     * refresh.
+     */
+    private void refreshCachedKeyStore() {
+        // Return if not enough time has passed for the delegate KeyStore to be refreshed.
+        if (now.instant().isBefore(cacheExpiredTime)) {
+            return;
+        }
+
+        // Set the time when refresh should be checked next.
+        cacheExpiredTime = now.instant().plus(cacheTtl);
+
+        try {
+            refresh();
+        } catch (Exception e) {
+            log.debug("Failed to refresh:", e);
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Replace the {@code KeyStore} delegate,
+     *
+     * @param delegate KeyStore instance that becomes the delegate.
+     */
+    void setKeyStoreDelegate(KeyStore delegate) {
+        log.debug("Setting new KeyStore delegate");
+        this.delegate.set(new Delegate(delegate));
+    }
+
+    @Override
+    public Key engineGetKey(String alias, char[] password) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.getKey(alias, password);
+        } catch (KeyStoreException e) {
+            log.error("getKey() failed", e);
+            return null;
+        } catch (UnrecoverableKeyException e) {
+            // UnrecoverableKeyException is thrown when given password for keystore entry was incorrect.
+            // JSSE X509KeyManagerImpl.getEntry() unfortunately hides the error by catching and ignoring the exception.
+            // To help troubleshooting, we catch the exception here as well and print the error.
+            log.error("getKey() failed", e);
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Override
+    public Certificate[] engineGetCertificateChain(String alias) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.getCertificateChain(alias);
+        } catch (KeyStoreException e) {
+            log.error("getCertificateChain() failed:", e);
+            return new Certificate[0];
+        }
+    }
+
+    @Override
+    public Certificate engineGetCertificate(String alias) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.getCertificate(alias);
+        } catch (KeyStoreException e) {
+            log.error("getCertificate() failed:", e);
+            return null;
+        }
+    }
+
+    @Override
+    public Date engineGetCreationDate(String alias) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.getCreationDate(alias);
+        } catch (KeyStoreException e) {
+            log.error("getCreationDate() failed:", e);
+            return null;
+        }
+    }
+
+    /**
+     * Return aliases in sorted order.
+     * This is different than the order used by underlying KeyStore.
+     * Sorting aliases enables user to have expected fallback behavior when KeyManager selects server certificate.
+     * This can be useful in cases when client does not set TLS SNI or unknown SNI servername is requested.
+     */
+    @Override
+    public Enumeration<String> engineAliases() {
+        refreshCachedKeyStore();
+        return Collections.enumeration(new ArrayList<>(delegate.get().sortedAliases));
+    }
+
+    @Override
+    public boolean engineContainsAlias(String alias) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.containsAlias(alias);
+        } catch (KeyStoreException e) {
+            log.error("containsAlias() failed:", e);
+            return false;
+        }
+    }
+
+    @Override
+    public int engineSize() {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.size();
+        } catch (KeyStoreException e) {
+            log.error("size() failed:", e);
+            return 0;
+        }
+    }
+
+    @Override
+    public boolean engineIsKeyEntry(String alias) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.isKeyEntry(alias);
+        } catch (KeyStoreException e) {
+            log.error("isKeyEntry() failed:", e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean engineIsCertificateEntry(String alias) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.isCertificateEntry(alias);
+        } catch (KeyStoreException e) {
+            log.error("isCertificateEntry() failed;", e);
+            return false;
+        }
+    }
+
+    @Override
+    public String engineGetCertificateAlias(Certificate cert) {
+        refreshCachedKeyStore();
+
+        try {
+            return delegate.get().keyStore.getCertificateAlias(cert);
+        } catch (KeyStoreException e) {
+            log.error("getCertificateAlias() failed:", e);
+            return null;
+        }
+    }
+
+    @Override
+    public void engineLoad(InputStream stream, char[] password)
+            throws IOException, NoSuchAlgorithmException, CertificateException {
+        // Nothing to do here since implementations of this class have their own means to load certificates and keys.
+        log.debug("engineLoad()");
+    }
+
+    private static final String IMMUTABLE_KEYSTORE_ERR = "Modifying keystore is not supported";
+
+    @Override
+    public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain)
+            throws KeyStoreException {
+        throw new UnsupportedOperationException(IMMUTABLE_KEYSTORE_ERR);
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+        throw new UnsupportedOperationException(IMMUTABLE_KEYSTORE_ERR);
+    }
+
+    @Override
+    public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+        throw new UnsupportedOperationException(IMMUTABLE_KEYSTORE_ERR);
+    }
+
+    @Override
+    public void engineDeleteEntry(String alias) throws KeyStoreException {
+        throw new UnsupportedOperationException(IMMUTABLE_KEYSTORE_ERR);
+    }
+
+    @Override
+    public void engineStore(OutputStream stream, char[] password)
+            throws IOException, NoSuchAlgorithmException, CertificateException {
+        throw new UnsupportedOperationException(IMMUTABLE_KEYSTORE_ERR);
+    }
+
+    class Delegate {
+        KeyStore keyStore;
+        List<String> sortedAliases;
+
+        Delegate(KeyStore ks) {
+            this.keyStore = ks;
+
+            try {
+                // Keep aliases sorted to entries returned.
+                sortedAliases = Collections.list(ks.aliases());
+                Collections.sort(sortedAliases);
+            } catch (KeyStoreException e) {
+                // Ignore exception.
+                log.error("Failed getting aliases:", e);
+            }
+        }
+    }
+
+}

--- a/services/src/main/java/org/keycloak/keystore/PemCredentialFactory.java
+++ b/services/src/main/java/org/keycloak/keystore/PemCredentialFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Reads PEM files and constructs {@code Certificates} and {@code PrivateKeys} from them.
+ */
+public class PemCredentialFactory {
+
+    private static final Logger log = Logger.getLogger(PemCredentialFactory.class);
+
+    private PemCredentialFactory() {
+        // Empty.
+    }
+
+    /**
+     * Reads PEM encoded certificate or certificate bundle from given file and constructs an array of {@code Certificates}.
+     *
+     * @param path Path to PEM file.
+     * @return Array of one or more certificates.
+     */
+    public static Certificate[] generateCertificates(Path path) throws IOException, CertificateException {
+        log.debugv("Loading PEM certificate(s) from {0}", path);
+        List<Certificate> certs = new ArrayList<>();
+        try (InputStream input = Files.newInputStream(path)) {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            for (Certificate c : cf.generateCertificates(input)) {
+                certs.add(c);
+            }
+        }
+        return certs.toArray(new Certificate[0]);
+    }
+
+    /**
+     * Reads PEM encoded private key (PKCS#8) from given file and construct {@code PrivateKey}.
+     *
+     * @param path Path to PEM file.
+     * @return Private key.
+     */
+    public static PrivateKey generatePrivateKey(Path path)
+            throws IOException, InvalidKeySpecException, NoSuchAlgorithmException {
+        log.debugv("Loading PEM private key from {0}", path);
+
+        // Loop through PEM blocks until PRIVATE KEY type.
+        PemReader reader = new PemReader(path);
+        PemReader.Block block = null;
+        while ((block = reader.decode()) != null) {
+            if (block.getType().equals("PRIVATE KEY")) {
+                break;
+            }
+        }
+
+        // Throw exception if no PRIVATE KEY in PEM file.
+        if (block == null) {
+            log.errorv("Cannot find PRIVATE KEY PEM block in {0}", path);
+            throw new IllegalArgumentException("PEM does not have private key: " + path);
+        }
+
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(block.getBytes());
+
+        // First try to parse content as RSA key.
+        PrivateKey pkey = tryDecodePkey("RSA", spec);
+
+        // If it did not succeed, try parse content as EC key.
+        if (pkey == null) {
+            pkey = tryDecodePkey("EC", spec);
+        }
+
+        // Throw exception if parsing failed for all algorithms.
+        if (pkey == null) {
+            log.errorv("Cannot decode private key {0}", path);
+            throw new InvalidKeySpecException("Invalid private key: " + path);
+        }
+
+        return pkey;
+    }
+
+    /**
+     * Attempts to decode PKCS8 key using given algorithm.
+     *
+     * @param algo Key algorithm name.
+     * @param spec Private key spec,
+     * @return PrivateKey pointer if successful, null if private key could not be parsed as given algorithm.
+     */
+    private static PrivateKey tryDecodePkey(String algo, PKCS8EncodedKeySpec spec) throws NoSuchAlgorithmException {
+        PrivateKey pkey = null;
+        try {
+            pkey = KeyFactory.getInstance(algo).generatePrivate(spec);
+            log.debugv("Found {0} private key", algo);
+        } catch (InvalidKeySpecException e) {
+            // Ignore exception and return null if decoding fails.
+        }
+        return pkey;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/keystore/PemReader.java
+++ b/services/src/main/java/org/keycloak/keystore/PemReader.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+/**
+ * Reads PEM encoded files and PEM bundles.
+ */
+public class PemReader {
+
+    private static final String PEM_START = "-----BEGIN ";
+    private static final String PEM_END = "-----END ";
+    private static final String PEM_END_OF_LINE = "-----";
+
+    // Parser state.
+    private boolean isInsideBlock = false;
+    BufferedReader reader;
+
+    /**
+     * Constructs new reader that decodes PEM block(s) from given file.
+     *
+     * @param path Path to PEM file.
+     */
+    PemReader(Path path) throws IOException {
+        reader = new BufferedReader(new InputStreamReader(Files.newInputStream(path)));
+    }
+
+    /**
+     * Constructs new reader to decode PEM block(s) from given byte array.
+     *
+     * @param data Buffer containing PEM block(s).
+     */
+    PemReader(byte[] data) {
+        ByteArrayInputStream stream = new ByteArrayInputStream(data);
+        InputStreamReader streamReader = new InputStreamReader(stream, StandardCharsets.UTF_8);
+        reader = new BufferedReader(streamReader);
+    }
+
+    /**
+     * Decodes next PEM block in the bundle.
+     *
+     * @return Block object that holds the decoded data or null if no more PEM blocks can be decoded.
+     */
+    public Block decode() throws IOException {
+        String line;
+        String type = "";
+        StringBuilder builder = new StringBuilder();
+
+        while ((line = reader.readLine()) != null) {
+            if (line.startsWith(PEM_START)) {
+                isInsideBlock = true;
+                type = parseType(line);
+            } else if (isInsideBlock && line.startsWith(PEM_END)) {
+                isInsideBlock = false;
+                byte[] encoded = String.valueOf(builder).getBytes();
+                return new Block(type, Base64.getMimeDecoder().decode(encoded));
+            } else if (isInsideBlock) {
+                builder.append(line);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns block type from PEM header.
+     * For example if header is {@code -----BEGIN PRIVATE KEY-----} then return {@code "PRIVATE KEY"}.
+     */
+    private String parseType(String line) {
+        int start = PEM_START.length();
+        int end = line.lastIndexOf(PEM_END_OF_LINE);
+        return line.substring(start, end);
+    }
+
+    /**
+     * Represents PEM block, that is, the content from PEM file that is enclosed between
+     * {@code -----BEGIN [TYPE]-----} and {@code -----END [TYPE]-----} headers.
+     */
+    public class Block {
+        private final String type;
+        private final byte[] bytes;
+
+        Block(String type, byte[] bytes) {
+            this.type = type;
+            this.bytes = bytes;
+        }
+
+        /**
+         * Get type of the PEM block.
+         * For example "CERTIFICATE" or "PRIVATE KEY"
+         */
+        public String getType() {
+            return type;
+        }
+
+        /**
+         * Get bytes of the decoded PEM block.
+         */
+        public byte[] getBytes() {
+            return bytes;
+        }
+    }
+
+}

--- a/services/src/main/java/org/keycloak/keystore/ReloadingKeyStore.java
+++ b/services/src/main/java/org/keycloak/keystore/ReloadingKeyStore.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * KeyStore that can reload the wrapped delegate {@code KeyStore} when the backing files have been changed on disk.
+ */
+public class ReloadingKeyStore extends KeyStore {
+
+    protected ReloadingKeyStore(KeyStoreSpi keyStoreSpi)
+            throws NoSuchAlgorithmException, CertificateException, IOException {
+
+        super(keyStoreSpi, null, "ReloadingKeyStore");
+
+        // Calling load(), even with null arguments, will initialize the KeyStore to expected state.
+        load(null, null);
+    }
+
+    /**
+     * KeyStore.Builder creates reloading keystores for various types of credential files.
+     */
+    public static class Builder extends KeyStore.Builder {
+
+        private final KeyStore keyStore;
+        private final ProtectionParameter protection;
+
+        // Map<alias, protection>
+        private Map<String, ProtectionParameter> aliasProtection;
+
+        private Builder(KeyStore keyStore, char[] password) {
+            this.keyStore = keyStore;
+            this.protection = new PasswordProtection(password);
+        }
+
+        private Builder(KeyStore keyStore, char[] password, Map<String, char[]> aliasPasswords) {
+            this.keyStore = keyStore;
+            this.protection = new PasswordProtection(password);
+            this.aliasProtection = new HashMap<>();
+            for (Map.Entry<String, char[]> entry : aliasPasswords.entrySet()) {
+                aliasProtection.put(entry.getKey(), new PasswordProtection(entry.getValue()));
+            }
+        }
+
+        /**
+         * Returns the KeyStore described by this object.
+         *
+         * @return Keystore described by this object.
+         */
+        @Override
+        public KeyStore getKeyStore() {
+            return keyStore;
+        }
+
+        /**
+         * Returns the ProtectionParameters (password) that should be used to obtain the Entry with the given alias.
+         *
+         * @param alias Alias for key entry.
+         * @return ProtectionParameters (password) for the key entry.
+         */
+        @Override
+        public ProtectionParameter getProtectionParameter(String alias) {
+            // Use keystore password, if individual alias passwords are not defined.
+            if (aliasProtection == null) {
+                return protection;
+            }
+
+            // Certain Java versions pass alias in a format to getProtectionParameter(), which was meant to be internal
+            // to NewSunX509 X509KeyManagerImpl. This was fixed in JDK17.
+            //
+            //   X509KeyManagerImpl calls getProtectionParameter with incorrect alias
+            //   https://bugs.openjdk.org/browse/JDK-8264554
+            //   https://github.com/openjdk/jdk/pull/3326
+            //
+            // For compatibility also with older versions, parse the plain alias from NewSunX509 KeyManager internal
+            // (prefixed) alias.
+            // https://github.com/openjdk/jdk/blob/6e55a72f25f7273e3a8a19e0b9a97669b84808e9/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java#L237-L265
+            Objects.requireNonNull(alias);
+            int firstDot = alias.indexOf('.');
+            int secondDot = alias.indexOf('.', firstDot + 1);
+            if ((firstDot == -1) || (secondDot == firstDot)) {
+                return aliasProtection.getOrDefault(alias, protection);
+            }
+            String requestedAlias = alias.substring(secondDot + 1);
+            return aliasProtection.getOrDefault(requestedAlias, protection);
+        }
+
+        /**
+         * Creates KeyStore builder for given PKCS#12 or JKS file.
+         *
+         * @param type KeyStore type such as {@code "PKCS12"} or {@code "JKS"}.
+         * @param path Path to the keystore file.
+         * @param password Password used to decrypt the KeyStore.
+         * @return The KeyStore builder.
+         */
+        public static KeyStore.Builder fromKeyStoreFile(String type, Path path, String password)
+                throws NoSuchAlgorithmException, CertificateException, KeyStoreException,
+                IOException {
+            return new Builder(new ReloadingKeyStore(new ReloadingKeyStoreFileSpi(type, path, password)),
+                    password.toCharArray());
+        }
+
+        /**
+         * Creates KeyStore builder for given PKCS#12 or JKS file.
+         *
+         * @param type KeyStore type such as {@code "PKCS12"} or {@code "JKS"}.
+         * @param path Path to the keystore file.
+         * @param password Password used to decrypt the KeyStore.
+         * @param aliasPasswords Passwords used to decrypt keystore entries. Map of: alias (key), password (value).
+         * @return The KeyStore builder.
+         */
+        public static KeyStore.Builder fromKeyStoreFile(String type, Path path, String password,
+                Map<String, char[]> aliasPasswords)
+                throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException {
+            return new Builder(new ReloadingKeyStore(new ReloadingKeyStoreFileSpi(type, path, password)),
+                    password.toCharArray(), aliasPasswords);
+        }
+
+        /**
+         * Creates KeyStore builder for given certificate and private key files.
+         * Certificate in position {@code certs[n]} must match the private key in position {@code keys[n]}.
+         *
+         * @param certs List of paths to certificates.
+         * @param keys List of keys to private keys.
+         * @return The KeyStore builder.
+         */
+        public static KeyStore.Builder fromPem(List<Path> certs, List<Path> keys)
+                throws NoSuchAlgorithmException, CertificateException, IllegalArgumentException, KeyStoreException,
+                InvalidKeySpecException, IOException {
+
+            if (keys.size() < certs.size()) {
+                throw new IllegalArgumentException("Missing private key");
+            } else if (keys.size() > certs.size()) {
+                throw new IllegalArgumentException("Missing X.509 certificate");
+            } else if (keys.isEmpty()) {
+                throw new IllegalArgumentException("No credentials configured");
+            }
+
+            ReloadingPemFileKeyStoreSpi spi = new ReloadingPemFileKeyStoreSpi();
+
+            Iterator<Path> cpi = certs.iterator();
+            Iterator<Path> kpi = keys.iterator();
+            while (cpi.hasNext() && kpi.hasNext()) {
+                spi.addKeyEntry(cpi.next(), kpi.next());
+            }
+
+            return new Builder(new ReloadingKeyStore(spi), ReloadingPemFileKeyStoreSpi.IN_MEMORY_KEYSTORE_PASSWORD);
+        }
+
+        /**
+         * Creates KeyStore builder for given certificate and private key file.
+         *
+         * @param cert Path to certificate.
+         * @param key Path to private key.
+         * @return The KeyStore builder.
+         */
+        public static KeyStore.Builder fromPem(Path cert, Path key)
+                throws NoSuchAlgorithmException, CertificateException, IllegalArgumentException, KeyStoreException,
+                InvalidKeySpecException, IOException {
+
+            ReloadingPemFileKeyStoreSpi spi = new ReloadingPemFileKeyStoreSpi();
+            spi.addKeyEntry(cert, key);
+            return new Builder(new ReloadingKeyStore(spi), ReloadingPemFileKeyStoreSpi.IN_MEMORY_KEYSTORE_PASSWORD);
+        }
+
+        /**
+         * Creates KeyStore builder for certificate path(s).
+         *
+         * @param cert Path to certificate.
+         * @return The KeyStore builder.
+         */
+        public static KeyStore.Builder fromPem(Path... cert) throws KeyStoreException, InvalidKeySpecException,
+                NoSuchAlgorithmException, CertificateException, IOException {
+
+            ReloadingPemFileKeyStoreSpi spi = new ReloadingPemFileKeyStoreSpi();
+            for (Path c : cert) {
+                spi.addCertificateEntry(c);
+            }
+            return new Builder(new ReloadingKeyStore(spi), ReloadingPemFileKeyStoreSpi.IN_MEMORY_KEYSTORE_PASSWORD);
+        }
+    }
+
+    /**
+     * Set how frequently the KeyStore(s) will check if the underlying files have changed and reload is required.
+     * The check still happens only when credentials are used. TTL of one second means that the file modification
+     * will be checked at most once per second, depending when the KeyStore is used next.
+     *
+     * @param ttl Minimum time-to-live for in-memory delegate {@code KeyStore}.
+     */
+    public static void setDefaultKeyStoreCacheTtl(Duration ttl) {
+        DelegatingKeyStoreSpi.cacheTtl = ttl;
+    }
+}

--- a/services/src/main/java/org/keycloak/keystore/ReloadingKeyStoreFileSpi.java
+++ b/services/src/main/java/org/keycloak/keystore/ReloadingKeyStoreFileSpi.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+
+import org.jboss.logging.Logger;
+
+/**
+ * {@code KeyStoreSpi} implementation that hot-reloads {@code KeyStore} when the backing file changes.
+ */
+public class ReloadingKeyStoreFileSpi extends DelegatingKeyStoreSpi {
+
+  private static final Logger log = Logger.getLogger(ReloadingKeyStoreFileSpi.class);
+
+  private final String type;
+  private final Path path;
+  private final char[] password;
+  private FileTime lastModified;
+
+  public ReloadingKeyStoreFileSpi(String type, Path path, String password) throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
+    if (password == null) {
+      throw new IllegalArgumentException("Password must not be null");
+    }
+
+    this.type = type;
+    this.path = path;
+    this.password = password.toCharArray();
+
+    refresh();
+  }
+
+  /**
+   * Reload keystore if it has been modified on disk since is was last loaded.
+   * @throws IOException
+   * @throws KeyStoreException
+   * @throws CertificateException
+   * @throws NoSuchAlgorithmException
+   */
+  void refresh() throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+    // If keystore has been previously loaded, check the modification timestamp to decide if reload is needed.
+    if ((lastModified != null) && (lastModified.compareTo(Files.getLastModifiedTime(path)) >= 0)) {
+      // File was not modified since last reload: do nothing.
+      return;
+    }
+
+    // Load keystore from disk.
+    log.debugv("Reloading keystore {0}", path);
+    KeyStore ks = KeyStore.getInstance(type);
+    ks.load(Files.newInputStream(path), password);
+    setKeyStoreDelegate(ks);
+    this.lastModified = Files.getLastModifiedTime(path);
+  }
+
+}

--- a/services/src/main/java/org/keycloak/keystore/ReloadingPemFileKeyStoreSpi.java
+++ b/services/src/main/java/org/keycloak/keystore/ReloadingPemFileKeyStoreSpi.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.keystore;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+
+/**
+ * {@code KeyStoreSpi} implementation that hot-reloads certificates and private keys from PEM files when the backing files change.
+ */
+public class ReloadingPemFileKeyStoreSpi extends DelegatingKeyStoreSpi {
+
+    // Empty password used for the in-memory KeyStore that holds the credentials loaded from PEM files.
+    protected static final char[] IN_MEMORY_KEYSTORE_PASSWORD = "".toCharArray();
+
+    private static final Logger log = Logger.getLogger(ReloadingPemFileKeyStoreSpi.class);
+
+    // List of objects holding the path of certificates and private keys and their last known modification timestamps.
+    private final List<KeyFileEntry> keyFileEntries = new ArrayList<>();
+
+    // List of objects holding the path of the certificates and their last known modification timestamps.
+    private final List<CertificateFileEntry> certificateFileEntries = new ArrayList<>();
+
+    public ReloadingPemFileKeyStoreSpi() {
+        // Empty.
+    }
+
+    /**
+     * Adds new key entry (certificate and private key) and recreates the {@code KeyStore}.
+     *
+     * @param cert Path to certificate file in PEM format.
+     * @param key Path to private key file in PEM format.
+     * @throws IOException
+     * @throws CertificateException
+     * @throws InvalidKeySpecException
+     * @throws KeyStoreException
+     * @throws NoSuchAlgorithmException
+     */
+    public void addKeyEntry(Path cert, Path key) throws IOException, KeyStoreException, InvalidKeySpecException, NoSuchAlgorithmException, CertificateException {
+        keyFileEntries.add(new KeyFileEntry(cert, key));
+        setKeyStoreDelegate(createKeyStore());
+    }
+
+    /**
+     * Adds new certificate entry and recreates the {@code KeyStore}.
+     *
+     * @param cert Path to certificate file in PEM format.
+     * @throws IOException
+     * @throws CertificateException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     * @throws KeyStoreException
+     */
+    public void addCertificateEntry(Path cert) throws IOException, KeyStoreException, InvalidKeySpecException, NoSuchAlgorithmException, CertificateException {
+        certificateFileEntries.add(new CertificateFileEntry(cert));
+        setKeyStoreDelegate(createKeyStore());
+    }
+
+    /**
+     * Reload certificate and key files if they have been modified on disk since they were last loaded.
+     * @throws IOException
+     * @throws CertificateException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     * @throws KeyStoreException
+     */
+    void refresh() throws KeyStoreException, InvalidKeySpecException, NoSuchAlgorithmException, CertificateException,
+            IOException {
+        // Check if any of the files has been updated.
+        // If yes, update the last modification timestamp for the file(s) and recreate delegate KeyStore with new content.
+        boolean wasReloaded = false;
+        int i = 0;
+        for (KeyFileEntry e : keyFileEntries) {
+            if (e.needsReload()) {
+                keyFileEntries.set(i, new KeyFileEntry(e.certPath, e.keyPath));
+                wasReloaded = true;
+            }
+            i++;
+        }
+        i = 0;
+        for (CertificateFileEntry e : certificateFileEntries) {
+            if (e.needsReload()) {
+                certificateFileEntries.set(i, new CertificateFileEntry(e.certPath));
+                wasReloaded = true;
+            }
+            i++;
+        }
+        // Re-generate KeyStore.
+        if (wasReloaded) {
+            log.debug("Refreshing KeyStore");
+            setKeyStoreDelegate(createKeyStore());
+        }
+    }
+
+    /**
+     * Create KeyStore containing given certificates and private keys.
+     * @throws KeyStoreException
+     * @throws IOException
+     * @throws CertificateException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    private KeyStore createKeyStore() throws KeyStoreException, InvalidKeySpecException, NoSuchAlgorithmException,
+            CertificateException, IOException {
+        log.debug("Creating new in-memory PKCS12 KeyStore.");
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+
+        // Calling load(), even with null arguments, will initialize the KeyStore to expected state.
+        ks.load(null, null);
+
+        int i = 0;
+
+        // Load certificates + private keys.
+        for (KeyFileEntry e : keyFileEntries) {
+            String alias = String.format("%04d", i++);
+            log.debugv("Adding key entry with alias {0}: {1}, {2}", alias, e.keyPath, e.certPath);
+            ks.setKeyEntry(alias, PemCredentialFactory.generatePrivateKey(e.keyPath), IN_MEMORY_KEYSTORE_PASSWORD,
+                    PemCredentialFactory.generateCertificates(e.certPath));
+        }
+        // Load trusted certificates.
+        for (CertificateFileEntry e : certificateFileEntries) {
+            String alias = String.format("%04d", i++);
+            log.debugv("Adding certificate entry with alias {0}: {1}", alias, e.certPath);
+            for (Certificate c : PemCredentialFactory.generateCertificates(e.certPath)) {
+                ks.setCertificateEntry(alias, c);
+            }
+        }
+
+        return ks;
+    }
+
+    /**
+     * Holds the path of certificate and private key and their last known modification timestamp.
+     */
+    class KeyFileEntry {
+        private final Path certPath;
+        private final Path keyPath;
+        private final FileTime certLastModified;
+        private final FileTime keyLastModified;
+
+        KeyFileEntry(Path certPath, Path keyPath) throws IOException {
+            this.certPath = certPath;
+            this.keyPath = keyPath;
+            this.certLastModified = Files.getLastModifiedTime(certPath);
+            this.keyLastModified = Files.getLastModifiedTime(keyPath);
+        }
+
+        boolean needsReload() throws IOException {
+            return (certLastModified.compareTo(Files.getLastModifiedTime(certPath)) < 0) ||
+                    (keyLastModified.compareTo(Files.getLastModifiedTime(keyPath)) < 0);
+        }
+    }
+
+    /**
+     * Holds the path of a certificate and its last known modification timestamp.
+     */
+    class CertificateFileEntry {
+        private final Path certPath;
+        private final FileTime certLastModified;
+
+        CertificateFileEntry(Path certPath) throws IOException {
+            this.certPath = certPath;
+            this.certLastModified = Files.getLastModifiedTime(certPath);
+        }
+
+        boolean needsReload() throws IOException {
+            return certLastModified.compareTo(Files.getLastModifiedTime(certPath)) < 0;
+        }
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.keystore.KeyStoreProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.keystore.KeyStoreProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2022 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.keystore.DefaultKeyStoreProvider

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
@@ -27,6 +27,10 @@ spi-hostname-default-frontend-url = ${keycloak.frontendUrl:}
 spi-truststore-file-file=${kc.home.dir}/conf/keycloak.truststore
 spi-truststore-file-password=secret
 
+# KeyStore Provider
+spi-keystore-default-ldap-keystore-file=${kc.home.dir}/conf/keycloak.jks
+spi-keystore-default-ldap-keystore-password=secret
+
 # Declarative User Profile
 spi-user-profile-provider=declarative-user-profile
 spi-user-profile-declarative-user-profile-read-only-attributes=deniedFoo,deniedBar*,deniedSome/thing,deniedsome*thing

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -31,6 +31,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -49,14 +50,6 @@ public class LDAPRule extends ExternalResource {
 
     public static final String LDAP_CONNECTION_PROPERTIES_LOCATION = "classpath:ldap/ldap-connection.properties";
 
-    private static final String PROPERTY_ENABLE_ACCESS_CONTROL = "enableAccessControl";
-
-    private static final String PROPERTY_ENABLE_ANONYMOUS_ACCESS = "enableAnonymousAccess";
-
-    private static final String PROPERTY_ENABLE_SSL = "enableSSL";
-
-    private static final String PROPERTY_ENABLE_STARTTLS = "enableStartTLS";
-
     private static final String PROPERTY_KEYSTORE_FILE = "keystoreFile";
 
     private static final String PRIVATE_KEY = "dependency/keystore/keycloak.jks";
@@ -67,7 +60,8 @@ public class LDAPRule extends ExternalResource {
     private LDAPEmbeddedServer ldapEmbeddedServer;
     private LDAPAssume assume;
 
-    protected Properties defaultProperties = new Properties();
+    protected Properties serverProperties = new Properties();
+    protected Map<String, String> clientConfig = new HashMap<>();
 
     public LDAPRule assumeTrue(LDAPAssume assume) {
         this.assume = assume;
@@ -76,8 +70,6 @@ public class LDAPRule extends ExternalResource {
 
     @Override
     public void before() throws Throwable {
-        String connectionPropsLocation = getConnectionPropertiesLocation();
-        ldapTestConfiguration = LDAPTestConfiguration.readConfiguration(connectionPropsLocation);
 
         Assume.assumeTrue("Assumption in LDAPRule is false. Skiping the test", assume==null || assume.assumeTrue(ldapTestConfiguration));
 
@@ -90,73 +82,111 @@ public class LDAPRule extends ExternalResource {
 
     @Override
     public Statement apply(Statement base, Description description) {
+        String connectionPropsLocation = getConnectionPropertiesLocation();
+        ldapTestConfiguration = LDAPTestConfiguration.readConfiguration(connectionPropsLocation);
+
         // Default bind credential value
-        defaultProperties.setProperty(LDAPConstants.BIND_CREDENTIAL, "secret");
-        defaultProperties.setProperty(LDAPConstants.CONNECTION_POOLING, "true");
+        serverProperties.setProperty(LDAPConstants.BIND_CREDENTIAL, "secret");
+        serverProperties.setProperty(LDAPConstants.CONNECTION_POOLING, "true");
         // Default values of the authentication / access control method and connection encryption to use on the embedded
         // LDAP server upon start if not (re)set later via the LDAPConnectionParameters annotation directly on the test
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "true");
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "false");
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "true");
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "false");
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "true");
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "false");
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "true");
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "false");
         // Default LDAP server confidentiality required value
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "false");
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "false");
 
         // Don't auto-update LDAP connection URL read from properties file for LDAP over SSL case even if it's wrong
         // (AKA don't try to guess, let the user to get it corrected in the properties file first)
-        defaultProperties.setProperty("AUTO_UPDATE_LDAP_CONNECTION_URL", "false");
+        serverProperties.setProperty("AUTO_UPDATE_LDAP_CONNECTION_URL", "false");
+
+        // Default configuration for LDAP client.
+        clientConfig = ldapTestConfiguration.getLDAPConfig();
+
+        clientConfig.put(LDAPConstants.BIND_CREDENTIAL, "secret");
+        clientConfig.put(LDAPConstants.AUTH_TYPE, LDAPConstants.AUTH_TYPE_SIMPLE);
+        clientConfig.put(LDAPConstants.START_TLS, "false");
+        clientConfig.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_NEVER);
 
         Annotation ldapConnectionAnnotation = description.getAnnotation(LDAPConnectionParameters.class);
         if (ldapConnectionAnnotation != null) {
-            // Mark the LDAP connection URL as auto-adjustable to correspond to specific annotation as necessary
-            defaultProperties.setProperty("AUTO_UPDATE_LDAP_CONNECTION_URL", "true");
             LDAPConnectionParameters connectionParameters = (LDAPConnectionParameters) ldapConnectionAnnotation;
             // Configure the bind credential type of the LDAP rule depending on the provided annotation arguments
             switch (connectionParameters.bindCredential()) {
                 case SECRET:
                     log.debug("Setting bind credential to secret.");
-                    defaultProperties.setProperty(LDAPConstants.BIND_CREDENTIAL, "secret");
+                    serverProperties.setProperty(LDAPConstants.BIND_CREDENTIAL, "secret");
+                    clientConfig.put(LDAPConstants.BIND_CREDENTIAL, "secret");
                     break;
                 case VAULT:
                     log.debug("Setting bind credential to vault.");
-                    defaultProperties.setProperty(LDAPConstants.BIND_CREDENTIAL, VAULT_EXPRESSION);
+                    serverProperties.setProperty(LDAPConstants.BIND_CREDENTIAL, VAULT_EXPRESSION);
+                    clientConfig.put(LDAPConstants.BIND_CREDENTIAL, VAULT_EXPRESSION);
                     break;
             }
             // Configure the authentication method of the LDAP rule depending on the provided annotation arguments
             switch (connectionParameters.bindType()) {
                 case NONE:
                     log.debug("Enabling anonymous authentication method on the LDAP server.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "true");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "false");
+                    clientConfig.put(LDAPConstants.AUTH_TYPE, LDAPConstants.AUTH_TYPE_NONE);
+                    clientConfig.remove(LDAPConstants.BIND_DN);
+                    clientConfig.remove(LDAPConstants.BIND_CREDENTIAL);
                     break;
                 case SIMPLE:
                     log.debug("Disabling anonymous authentication method on the LDAP server.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "false");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "true");
+                    clientConfig.put(LDAPConstants.AUTH_TYPE, LDAPConstants.AUTH_TYPE_SIMPLE);
+                    break;
+                case EXTERNAL:
+                    log.debug("Enabling SASL EXTERNAL authentication method.");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ACCESS_CONTROL, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ADMIN_CERTIFICATE_KEYSTORE, new File(PROJECT_BUILD_DIRECTORY, PRIVATE_KEY).getAbsolutePath());
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ADMIN_CERTIFICATE_KEYSTORE_PASSWORD, "secret");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_REQUIRE_CLIENT_CERTIFICATE, "true");
+                    clientConfig.put(LDAPConstants.AUTH_TYPE, LDAPConstants.AUTH_TYPE_EXTERNAL);
                     break;
             }
             // Configure the connection encryption of the LDAP rule depending on the provided annotation arguments
             switch (connectionParameters.encryption()) {
                 case NONE:
                     log.debug("Disabling connection encryption on the LDAP server.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "false");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_BIND_PORT, "10389");
+                    clientConfig.put(LDAPConstants.START_TLS, "false");
+                    clientConfig.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_NEVER);
+                    clientConfig.put(LDAPConstants.CONNECTION_URL, "ldap://localhost:10389");
                     break;
                 case SSL:
                     log.debug("Enabling SSL connection encryption on the LDAP server.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "true");
                     // Require the LDAP server to accept only secured connections with SSL enabled
                     log.debug("Configuring the LDAP server to accepts only requests with a secured connection.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "true");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_BIND_LDAPS_PORT, "10636");
+                    // Use truststore from TruststoreSPI for LDAPS connections
+                    clientConfig.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY);
+                    clientConfig.put(LDAPConstants.CONNECTION_URL, "ldaps://localhost:10636");
+
                     break;
                 case STARTTLS:
                     log.debug("Enabling StartTLS connection encryption on the LDAP server.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS, "true");
                     // Require the LDAP server to accept only secured connections with StartTLS enabled
                     log.debug("Configuring the LDAP server to accepts only requests with a secured connection.");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "true");
-                    defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "true");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL, "false");
+                    serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_BIND_PORT, "10389");
+                    clientConfig.put(LDAPConstants.START_TLS, "true");
+                    // Use truststore from TruststoreSPI for STARTTLS connections
+                    clientConfig.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_ALWAYS);
+                    clientConfig.put(LDAPConstants.CONNECTION_URL, "ldap://localhost:10389");
                     break;
             }
         }
@@ -181,85 +211,16 @@ public class LDAPRule extends ExternalResource {
     }
 
     protected LDAPEmbeddedServer createServer() {
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_DSF, LDAPEmbeddedServer.DSF_INMEMORY);
-        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_LDIF_FILE, "classpath:ldap/users.ldif");
-        defaultProperties.setProperty(PROPERTY_CERTIFICATE_PASSWORD, "secret");
-        defaultProperties.setProperty(PROPERTY_KEYSTORE_FILE, new File(PROJECT_BUILD_DIRECTORY, PRIVATE_KEY).getAbsolutePath());
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_DSF, LDAPEmbeddedServer.DSF_INMEMORY);
+        serverProperties.setProperty(LDAPEmbeddedServer.PROPERTY_LDIF_FILE, "classpath:ldap/users.ldif");
+        serverProperties.setProperty(PROPERTY_CERTIFICATE_PASSWORD, "secret");
+        serverProperties.setProperty(PROPERTY_KEYSTORE_FILE, new File(PROJECT_BUILD_DIRECTORY, PRIVATE_KEY).getAbsolutePath());
 
-        return new LDAPEmbeddedServer(defaultProperties);
+        return new LDAPEmbeddedServer(serverProperties);
     }
 
     public Map<String, String> getConfig() {
-        Map<String, String> config = ldapTestConfiguration.getLDAPConfig();
-        String ldapConnectionUrl = config.get(LDAPConstants.CONNECTION_URL);
-        if (ldapConnectionUrl != null && defaultProperties.getProperty("AUTO_UPDATE_LDAP_CONNECTION_URL").equals("true")) {
-            if (
-                ldapConnectionUrl.startsWith("ldap://") &&
-                defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL).equals("true")
-               )
-            {
-                // Switch protocol prefix to "ldaps://" in connection URL if LDAP over SSL is requested
-                String updatedUrl = ldapConnectionUrl.replaceAll("ldap://", "ldaps://");
-                // Flip port number from LDAP to LDAPS
-                updatedUrl = updatedUrl.replaceAll(
-                    String.valueOf(ldapEmbeddedServer.getBindPort()),
-                    String.valueOf(ldapEmbeddedServer.getBindLdapsPort())
-                );
-                config.put(LDAPConstants.CONNECTION_URL, updatedUrl);
-                log.debugf("Using LDAP over SSL \"%s\" connection URL form over: \"%s\" since SSL connection was requested.", updatedUrl, ldapConnectionUrl);
-            }
-            if (
-                ldapConnectionUrl.startsWith("ldaps://") &&
-                !defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_SSL).equals("true")
-               )
-            {
-                // Switch protocol prefix back to "ldap://" in connection URL if LDAP over SSL flag is not set
-                String updatedUrl = ldapConnectionUrl.replaceAll("ldaps://", "ldap://");
-                // Flip port number from LDAPS to LDAP
-                updatedUrl = updatedUrl.replaceAll(
-                    String.valueOf(ldapEmbeddedServer.getBindLdapsPort()),
-                    String.valueOf(ldapEmbeddedServer.getBindPort())
-                );
-                config.put(LDAPConstants.CONNECTION_URL, updatedUrl);
-                log.debugf("Using plaintext / startTLS \"%s\" connection URL form over: \"%s\" since plaintext / startTLS connection was requested.", updatedUrl, ldapConnectionUrl);
-            }
-        }
-        switch (defaultProperties.getProperty(LDAPConstants.BIND_CREDENTIAL)) {
-            case VAULT_EXPRESSION:
-                config.put(LDAPConstants.BIND_CREDENTIAL, VAULT_EXPRESSION);
-                break;
-        }
-        switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS)) {
-            case "true":
-                config.put(LDAPConstants.AUTH_TYPE, LDAPConstants.AUTH_TYPE_NONE);
-                config.remove(LDAPConstants.BIND_DN);
-                config.remove(LDAPConstants.BIND_CREDENTIAL);
-                break;
-            default:
-                // Default to username + password LDAP authentication method
-                config.put(LDAPConstants.AUTH_TYPE, LDAPConstants.AUTH_TYPE_SIMPLE);
-        }
-        switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS)) {
-            case "true":
-                config.put(LDAPConstants.START_TLS, "true");
-                // Use truststore from TruststoreSPI also for StartTLS connections
-                config.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_ALWAYS);
-                break;
-            default:
-                // Default to startTLS disabled
-                config.put(LDAPConstants.START_TLS, "false");
-                // By default use truststore from TruststoreSPI only for LDAP over SSL connections
-                config.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY);
-        }
-        switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED)) {
-            case "true":
-                System.setProperty("PROPERTY_SET_CONFIDENTIALITY_REQUIRED", "true");
-                break;
-            default:
-                // Configure the LDAP server to accept not secured connections from clients by default
-                System.setProperty("PROPERTY_SET_CONFIDENTIALITY_REQUIRED", "false");
-        }
-        return config;
+        return clientConfig;
     }
 
     public int getSleepTime() {
@@ -294,7 +255,8 @@ public class LDAPRule extends ExternalResource {
 
         public enum BindType {
             NONE,
-            SIMPLE
+            SIMPLE,
+            EXTERNAL
         }
 
         public enum Encryption {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.junit.runners.MethodSorters;
 import org.keycloak.common.Profile;
+import org.keycloak.component.ComponentModel;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.models.LDAPConstants;
@@ -124,6 +125,10 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
             getTestingClient().server().run(session -> {
                 LDAPTestContext ctx = LDAPTestContext.init(session);
                 RealmModel appRealm = ctx.getRealm();
+
+                // Add attribute for client certificate for SASL EXTERNAL authentication in ApacheDS.
+                ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(appRealm);
+                LDAPTestUtils.addUserAttributeMapper(appRealm, ldapModel, "user-certificate-mapper", "user_certificate", "userCertificate");
 
                 // Delete all LDAP users
                 LDAPTestUtils.removeAllLDAPUsers(ctx.getLdapProvider(), appRealm);
@@ -330,6 +335,23 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
     @Test
     @LDAPConnectionParameters(bindCredential=LDAPConnectionParameters.BindCredential.VAULT, bindType=LDAPConnectionParameters.BindType.NONE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserCredentialVaultAuthenticationNoneEncryptionStartTLS() {
+        verifyConnectionUrlProtocolPrefix("ldap://");
+        runLDAPLoginTest();
+    }
+
+
+    // Check LDAP federated user (in)valid login(s) with SASL EXTERNAL authentication & SSL encryption enabled
+    @Test
+    @LDAPConnectionParameters(bindType=LDAPConnectionParameters.BindType.EXTERNAL, encryption=LDAPConnectionParameters.Encryption.SSL)
+    public void loginLDAPUserAuthenticationSASLExternalEncryptionSSL() {
+        verifyConnectionUrlProtocolPrefix("ldaps://");
+        runLDAPLoginTest();
+    }
+
+    // Check LDAP federated user (in)valid login(s) with SASL EXTERNAL authentication & startTLS encryption enabled
+    @Test
+    @LDAPConnectionParameters(bindType=LDAPConnectionParameters.BindType.EXTERNAL, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
+    public void loginLDAPUserAuthenticationSASLExternalEncryptionStartTLS() {
         verifyConnectionUrlProtocolPrefix("ldap://");
         runLDAPLoginTest();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -315,6 +315,15 @@
         }
     },
 
+    "keystore": {
+        "default": {
+            "ldapKeystoreFile": "${keycloak.truststore.file:target/dependency/keystore/keycloak.jks}",
+            "ldapKeystorePassword": "${keycloak.keystore.password:secret}"
+
+        }
+    },
+
+
     "jta-lookup": {
         "provider": "${keycloak.jta.lookup.provider:jboss}",
         "jboss" : {

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/CertificateMechanismHandler.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/CertificateMechanismHandler.java
@@ -1,0 +1,86 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+/* This file is originally copied from ApacheDS
+ * https://github.com/apache/directory-server/blob/2.0.0.AM26/protocol-ldap/src/main/java/org/apache/directory/server/ldap/handlers/sasl/external/certificate/CertificateMechanismHandler.java
+ * and modified to support client certificate authentication for the admin user too.
+ * https://github.com/apache/directory-server/pull/39
+ */
+
+package org.keycloak.util.ldap;
+
+import org.apache.directory.api.ldap.model.message.BindRequest;
+import org.apache.directory.server.core.api.CoreSession;
+import org.apache.directory.server.ldap.LdapSession;
+import org.apache.directory.server.ldap.handlers.sasl.AbstractMechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.SaslConstants;
+
+import javax.security.sasl.SaslServer;
+
+/**
+ * The External Sasl mechanism handler which to authenticate user by client certificate (ssl).
+ *
+ * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
+ */
+public class CertificateMechanismHandler extends AbstractMechanismHandler
+{
+    public SaslServer handleMechanism( LdapSession ldapSession, BindRequest bindRequest ) throws Exception
+    {
+        SaslServer ss = ( SaslServer ) ldapSession.getSaslProperty( SaslConstants.SASL_SERVER );
+
+        if ( ss == null )
+        {
+            String saslHost = ldapSession.getLdapServer().getSaslHost();
+            String userBaseDn = ldapSession.getLdapServer().getSearchBaseDn();
+            ldapSession.putSaslProperty( SaslConstants.SASL_HOST, saslHost );
+            ldapSession.putSaslProperty( SaslConstants.SASL_USER_BASE_DN, userBaseDn );
+
+            CoreSession adminSession = ldapSession.getLdapServer().getDirectoryService().getAdminSession();
+
+            ss = new ExternalSaslServer( ldapSession, adminSession, bindRequest );
+
+            ldapSession.putSaslProperty( SaslConstants.SASL_SERVER, ss );
+        }
+
+        return ss;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public void init( LdapSession ldapSession )
+    {
+        // Store the host in the ldap session
+        String saslHost = ldapSession.getLdapServer().getSaslHost();
+        ldapSession.putSaslProperty( SaslConstants.SASL_HOST, saslHost );
+    }
+
+
+    /**
+     * Remove the SaslServer and Mechanism property.
+     *
+     * @param ldapSession the Ldapsession instance
+     */
+    public void cleanup( LdapSession ldapSession )
+    {
+        ldapSession.clearSaslProperties();
+    }
+}

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/ExternalSaslServer.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/ExternalSaslServer.java
@@ -1,0 +1,205 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+/* This file is originally copied from ApacheDS
+ * https://github.com/apache/directory-server/blob/2.0.0.AM26/protocol-ldap/src/main/java/org/apache/directory/server/ldap/handlers/sasl/external/certificate/ExternalSaslServer.java
+ * and modified to support client certificate authentication for the admin user too.
+ * https://github.com/apache/directory-server/pull/39
+ */
+
+package org.keycloak.util.ldap;
+
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.directory.api.ldap.model.constants.AuthenticationLevel;
+import org.apache.directory.api.ldap.model.constants.SchemaConstants;
+import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.entry.Value;
+import org.apache.directory.api.ldap.model.exception.LdapAuthenticationException;
+import org.apache.directory.api.ldap.model.filter.EqualityNode;
+import org.apache.directory.api.ldap.model.message.BindRequest;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.util.Strings;
+import org.apache.directory.server.core.api.CoreSession;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.LdapPrincipal;
+import org.apache.directory.server.core.api.OperationEnum;
+import org.apache.directory.server.core.api.OperationManager;
+import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
+import org.apache.directory.server.core.api.interceptor.context.BindOperationContext;
+import org.apache.directory.server.core.api.interceptor.context.SearchOperationContext;
+import org.apache.directory.server.ldap.LdapSession;
+import org.apache.directory.server.ldap.handlers.sasl.AbstractSaslServer;
+import org.apache.directory.server.ldap.handlers.sasl.SaslConstants;
+import org.apache.mina.filter.ssl.SslFilter;
+
+import javax.naming.Context;
+import javax.net.ssl.SSLSession;
+import javax.security.sasl.SaslException;
+import java.security.cert.Certificate;
+
+
+/**
+ * A SaslServer implementation for certificate based SASL EXTERNAL mechanism.
+ *
+ * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
+ */
+public final class ExternalSaslServer extends AbstractSaslServer
+{
+    /**
+     * The possible states for the negotiation of a EXTERNAL mechanism.
+     */
+    private enum NegotiationState
+    {
+        INITIALIZED, // Negotiation has just started
+        COMPLETED // The user/password have been received
+    }
+
+    /** The current negotiation state */
+    private NegotiationState state;
+
+    /**
+     *
+     * Creates a new instance of ExternalSaslServer.
+     *
+     * @param ldapSession The associated LdapSession instance
+     * @param adminSession The Administrator session
+     * @param bindRequest The associated BindRequest object
+     */
+    ExternalSaslServer( LdapSession ldapSession, CoreSession adminSession, BindRequest bindRequest )
+    {
+        super( ldapSession, adminSession, bindRequest );
+        state = NegotiationState.INITIALIZED;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getMechanismName()
+    {
+        return SupportedSaslMechanisms.EXTERNAL;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public byte[] evaluateResponse( byte[] initialResponse ) throws SaslException
+    {
+        try
+        {
+            SSLSession sslSession = ( SSLSession ) getLdapSession().getIoSession().getAttribute( SslFilter.SSL_SESSION );
+            Certificate[] peerCertificates = sslSession.getPeerCertificates();
+
+            if ( null == peerCertificates || 1 > peerCertificates.length )
+            {
+                throw new SaslException( "No peer certificate provided - cancel bind." );
+            }
+
+            getLdapSession().setCoreSession( authenticate( peerCertificates[0] ) );
+            state = NegotiationState.COMPLETED;
+        }
+        catch ( Exception e )
+        {
+            throw new SaslException( "Error authentication using client certificate: " + ExceptionUtils.getStackTrace( e ), e );
+        }
+
+        return Strings.EMPTY_BYTES;
+    }
+
+
+    /**
+     * Provides {@code true} if negationstate is {@link NegotiationState#COMPLETED}
+     *
+     * @return {@code true} if completed, otherwise {@code false}
+     */
+    public boolean isComplete()
+    {
+        return state == NegotiationState.COMPLETED;
+    }
+
+
+    /**
+     * Try to authenticate the user against the underlying LDAP server.
+     * We identify the user using the provided peercertificate.
+     */
+    private CoreSession authenticate( Certificate peerCertificate ) throws Exception
+    {
+        // search for client certificate from users
+        CoreSession session = searchUserWithCertificate(peerCertificate, getLdapSession().getLdapServer().getSearchBaseDn());
+        if (session != null) {
+            return session;
+        }
+
+        // search for client certificate for admin user
+        session = searchUserWithCertificate(peerCertificate, "uid=admin,ou=system");
+        if (session != null) {
+            return session;
+        }
+
+        throw new LdapAuthenticationException("Cannot authenticate user cert=" + peerCertificate);
+    }
+
+    private CoreSession searchUserWithCertificate(Certificate peerCertificate, String baseDn) throws Exception
+    {
+        LdapSession ldapSession = getLdapSession();
+        CoreSession adminSession = getAdminSession();
+        DirectoryService directoryService = adminSession.getDirectoryService();
+        OperationManager operationManager = directoryService.getOperationManager();
+
+        // find user by userCertificate
+        EqualityNode<String> filter = new EqualityNode<>(
+                directoryService.getSchemaManager().getAttributeType(SchemaConstants.USER_CERTIFICATE_AT),
+                new Value(peerCertificate.getEncoded()));
+
+        SearchOperationContext searchContext = new SearchOperationContext( directoryService.getAdminSession() );
+        searchContext.setDn( directoryService.getDnFactory().create( baseDn ) );
+        searchContext.setScope( SearchScope.SUBTREE );
+        searchContext.setFilter( filter );
+        searchContext.setSizeLimit( 1 );
+        searchContext.setNoAttributes( true );
+
+        try ( EntryFilteringCursor cursor = operationManager.search( searchContext ) )
+        {
+            if (cursor.next()) {
+                Entry entry = cursor.get();
+
+                BindOperationContext bindContext = new BindOperationContext(ldapSession.getCoreSession());
+                bindContext.setDn(entry.getDn());
+                bindContext.setSaslMechanism(getMechanismName());
+                bindContext.setSaslAuthId(getBindRequest().getName());
+                bindContext.setIoSession(ldapSession.getIoSession());
+                bindContext.setInterceptors(directoryService.getInterceptors(OperationEnum.BIND));
+
+                operationManager.bind(bindContext);
+
+                ldapSession.putSaslProperty(SaslConstants.SASL_AUTHENT_USER, new LdapPrincipal(
+                        directoryService.getSchemaManager(), entry.getDn(), AuthenticationLevel.STRONG));
+                getLdapSession().putSaslProperty(Context.SECURITY_PRINCIPAL, getBindRequest().getName());
+
+                return bindContext.getSession();
+            }
+        }
+
+        return null;
+    }
+}

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
@@ -20,11 +20,16 @@ package org.keycloak.util.ldap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.directory.api.ldap.model.constants.SchemaConstants;
+import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.exception.LdapEntryAlreadyExistsException;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.message.ModifyRequest;
+import org.apache.directory.api.ldap.model.message.ModifyRequestImpl;
+import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.api.interceptor.Interceptor;
@@ -40,11 +45,13 @@ import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.directory.server.protocol.shared.transport.Transport;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.FindFile;
+import org.keycloak.common.util.KeystoreUtil;
 import org.keycloak.common.util.StreamUtil;
 
 import java.io.File;
 import java.io.InputStream;
 import java.security.KeyStore;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +77,9 @@ public class LDAPEmbeddedServer {
     public static final String PROPERTY_ENABLE_SSL = "enableSSL";
     public static final String PROPERTY_ENABLE_STARTTLS = "enableStartTLS";
     public static final String PROPERTY_SET_CONFIDENTIALITY_REQUIRED = "setConfidentialityRequired";
+    public static final String PROPERTY_ADMIN_CERTIFICATE_KEYSTORE = "adminCertificateKeyStore";
+    public static final String PROPERTY_ADMIN_CERTIFICATE_KEYSTORE_PASSWORD = "adminCredentialKeyStorePassword";
+    public static final String PROPERTY_REQUIRE_CLIENT_CERTIFICATE = "requireClientCertificate";
 
     private static final String DEFAULT_BASE_DN = "dc=keycloak,dc=org";
     private static final String DEFAULT_BIND_HOST = "localhost";
@@ -99,6 +109,9 @@ public class LDAPEmbeddedServer {
     protected boolean setConfidentialityRequired = false;
     protected String keystoreFile;
     protected String certPassword;
+    protected String adminCertificateKeyStore;
+    protected String adminCertificateKeyStorePassword;
+    protected boolean requireClientCertificate = false;
 
     protected DirectoryService directoryService;
     protected LdapServer ldapServer;
@@ -156,6 +169,9 @@ public class LDAPEmbeddedServer {
         this.setConfidentialityRequired = Boolean.valueOf(readProperty(PROPERTY_SET_CONFIDENTIALITY_REQUIRED, "false"));
         this.keystoreFile = readProperty(PROPERTY_KEYSTORE_FILE, null);
         this.certPassword = readProperty(PROPERTY_CERTIFICATE_PASSWORD, null);
+        this.adminCertificateKeyStore = readProperty(PROPERTY_ADMIN_CERTIFICATE_KEYSTORE, null);
+        this.adminCertificateKeyStorePassword = readProperty(PROPERTY_ADMIN_CERTIFICATE_KEYSTORE_PASSWORD, null);
+        this.requireClientCertificate = Boolean.valueOf(readProperty(PROPERTY_REQUIRE_CLIENT_CERTIFICATE, "false"));
     }
 
     protected String readProperty(String propertyName, String defaultValue) {
@@ -251,6 +267,9 @@ public class LDAPEmbeddedServer {
                         "objectClass: domain\n\n";
         importLdifContent(service, entryLdif);
 
+        if (adminCertificateKeyStore != null) {
+            setAdminCertificate(service);
+        }
 
         if (this.directoryServiceFactory.equals(DSF_INMEMORY)) {
             // Find Normalization interceptor in chain and add our range emulated interceptor
@@ -289,6 +308,10 @@ public class LDAPEmbeddedServer {
             if (enableSSL) {
                 Transport ldaps = new TcpTransport(this.bindHost, this.bindLdapsPort, 3, 50);
                 ldaps.setEnableSSL(true);
+                if (requireClientCertificate) {
+                    ((TcpTransport) ldaps).setWantClientAuth(true);
+                    ((TcpTransport) ldaps).setNeedClientAuth(true);
+                }
                 ldapServer.addTransports( ldaps );
                 if (ldaps.isSSLEnabled()) {
                     log.info("Enabled SSL support on the LDAP server.");
@@ -306,6 +329,12 @@ public class LDAPEmbeddedServer {
                         break;
                     }
                 }
+            }
+            // Enable SASL EXTERNAL authentication method for client certificate based
+            // authentication.
+            if (requireClientCertificate) {
+                ldapServer.addSaslMechanismHandler(SupportedSaslMechanisms.EXTERNAL, new CertificateMechanismHandler());
+                ((TcpTransport) ldap).setWantClientAuth(true);
             }
         }
 
@@ -390,6 +419,22 @@ public class LDAPEmbeddedServer {
         }
     }
 
+    private void setAdminCertificate(DirectoryService directoryService) throws Exception {
+        log.info("Setting LDAP admin certificate from keystore: " + adminCertificateKeyStore);
+        KeyStore store = KeystoreUtil.loadKeyStore(adminCertificateKeyStore, adminCertificateKeyStorePassword);
+        Enumeration<String> aliases = store.aliases();
+        byte[] certificate = null;
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            certificate = store.getCertificate(alias).getEncoded();
+        }
+
+        ModifyRequest modifyRequest = new ModifyRequestImpl();
+        Dn adminDn = new Dn("uid=admin,ou=system");
+        modifyRequest.setName(adminDn);
+        modifyRequest.add(SchemaConstants.USER_CERTIFICATE_AT, certificate);
+        directoryService.getAdminSession().modify(modifyRequest);
+    }
 
     public void stop() throws Exception {
         stopLdapServer();


### PR DESCRIPTION
Keystore SPI adds support to configure individual keystores for

- LDAP client for SASL EXTERNAL authentication
- HTTPS server certificate

Keystore SPI supports hot-reloading certificates when they are updated on disk and it supports loading certificates and private keys from PEM files in addition to keystore files.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
