### PR TITLE
Add legacy clientId claim back to service account token

### DIFF
--- a/common/src/main/java/org/keycloak/common/constants/ServiceAccountConstants.java
+++ b/common/src/main/java/org/keycloak/common/constants/ServiceAccountConstants.java
@@ -27,11 +27,13 @@ public interface ServiceAccountConstants {
     String SERVICE_ACCOUNT_USER_PREFIX = "service-account-";
 
     String CLIENT_ID_PROTOCOL_MAPPER = "Client ID";
+    String CLIENT_ID_LEGACY_PROTOCOL_MAPPER = "Client ID (Legacy)";
     String CLIENT_HOST_PROTOCOL_MAPPER = "Client Host";
     String CLIENT_ADDRESS_PROTOCOL_MAPPER = "Client IP Address";
 
     String CLIENT_ID_SESSION_NOTE = "clientId";
     String CLIENT_ID = "client_id";
+    String CLIENT_ID_LEGACY = "clientId";
     String CLIENT_HOST = "clientHost";
     String CLIENT_ADDRESS = "clientAddress";
 

--- a/services/src/main/java/org/keycloak/services/managers/ClientManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ClientManager.java
@@ -192,6 +192,15 @@ public class ClientManager {
                     true, true, true);
             client.addProtocolMapper(protocolMapper);
         }
+
+        if (client.getProtocolMapperByName(OIDCLoginProtocol.LOGIN_PROTOCOL, ServiceAccountConstants.CLIENT_ID_LEGACY_PROTOCOL_MAPPER) == null) {
+            logger.debugf("Creating service account protocol mapper '%s' for client '%s'", ServiceAccountConstants.CLIENT_ID_LEGACY_PROTOCOL_MAPPER, client.getClientId());
+            ProtocolMapperModel protocolMapper = UserSessionNoteMapper.createClaimMapper(ServiceAccountConstants.CLIENT_ID_LEGACY_PROTOCOL_MAPPER,
+                    ServiceAccountConstants.CLIENT_ID_LEGACY,
+                    ServiceAccountConstants.CLIENT_ID_LEGACY, "String",
+                    true, true, true);
+            client.addProtocolMapper(protocolMapper);
+        }
     }
 
     public void clientIdChanged(ClientModel client, ClientRepresentation newClientRepresentation) {


### PR DESCRIPTION
This change undo's [keycloak#16359](https://www.github.com/keycloak/keycloak/pull/16359) to keep backwards compatibility towards clients that expect old claim in token.